### PR TITLE
Negative numbers of processes means fewer than all cores

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,7 @@
 ### RUNNING / USING
 
 Pass `--gevented-processes` option to Nose or set `NOSE_GEVENTED_PROCESSES` env var to the number of worker processes you want to have.
-Setting a positive number will give you exactly that number of workers. Setting a negative number will make the plugin detect the number of CPUs and use that many workers.
+Setting a positive number will give you exactly that number of workers. Setting -1 will make the plugin detect the number of CPUs and use that many workers. Setting -2, -3, etc. will make the plugin use all CPU cores minus (-1 -(gevented_processes)) (i.e. -2 is all but one, -3 is all but two, etc.)
 Default value is zero - meaning the plug in is not used.
 
 Example:

--- a/nose_gevented_multiprocess/nose_gevented_multiprocess.py
+++ b/nose_gevented_multiprocess/nose_gevented_multiprocess.py
@@ -818,9 +818,9 @@ class GeventedMultiProcess(Plugin):
             help=("Spread test run among this many processes. "
                   "Set a number equal to the number of processors "
                   "in your machine for best results. "
-                  "Pass a negative number to have the number of "
-                  "processes automatically set to the number of "
-                  "cores. Passing 0 disables parallel "
+                  "Pass -1 to use all cores, and subsequent negative numbers "
+                  "to mean all cores minus that difference. "
+                  "Passing 0 disables parallel "
                   "testing. Default is 0 unless NOSE_GEVENTED_PROCESSES is "
                   "set. [NOSE_GEVENTED_PROCESSES]"))
         parser.add_option(
@@ -860,7 +860,11 @@ class GeventedMultiProcess(Plugin):
             workers = 0
 
         if workers < 0:
-            workers = multiprocessing.cpu_count()
+            # Use 1+ (-1*workers) forks
+            # In other words, -1 means 'all cores', -2 means 'all but 1',
+            # -3 'all but 2', etc. Anything nonsensical means disabled.
+            cpu_count = multiprocessing.cpu_count()
+            workers = (cpu_count + 1) - (-1 * workers)
 
         if workers > 1 and _gevent_patch():
             self.enabled = True


### PR DESCRIPTION
@jikamens Mind if I throw this on our fork?

Basically want my laptop to be usable while tests run by saying "use all but one" core.

---

So 'gevented-processes=-2' means 'all but one',
-3 means 'all but two', etc. Passing in a
nonsense value means disabled.
